### PR TITLE
Implementando y configurando la verificación de email con Fortify.

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,7 +10,7 @@ use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Sanctum\HasApiTokens;
 
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     use HasApiTokens;
     use HasFactory;

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -134,7 +134,7 @@ return [
     'features' => [
         Features::registration(),
         Features::resetPasswords(),
-        // Features::emailVerification(),
+        Features::emailVerification(),
         Features::updateProfileInformation(),
         Features::updatePasswords(),
         Features::twoFactorAuthentication([


### PR DESCRIPTION
Closes #86 - Se ha implementado la interfaz MustVerifyEmail al modelo User para forzar la verificación del email de manera obligatoria durante el registro.