### PR TITLE
(R39) Realizar Registro

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -2,11 +2,13 @@
 
 namespace App\Actions\Fortify;
 
+use App\Models\Profile;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 use Laravel\Jetstream\Jetstream;
+use Illuminate\Support\Str;
 
 class CreateNewUser implements CreatesNewUsers
 {
@@ -21,16 +23,33 @@ class CreateNewUser implements CreatesNewUsers
     public function create(array $input)
     {
         Validator::make($input, [
-            'name' => ['required', 'string', 'max:255'],
+            'name' => ['required', 'string', 'max:255', 'unique:users'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => $this->passwordRules(),
             'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature() ? ['accepted', 'required'] : '',
         ])->validate();
 
-        return User::create([
+        $user = User::create([
             'name' => $input['name'],
             'email' => $input['email'],
             'password' => Hash::make($input['password']),
+            'bio' => '',
         ]);
+
+        $slug = Str::slug($user->name);
+
+        Profile::create([
+            'url' => url("/users/$slug"),
+            'exp' => 0,
+            'honor' => 0,
+            'is_darkmode' => true,
+            'is_deleted' => false,
+            'is_banned' => false,
+            'rank_id' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $user;
     }
 }

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
-            $table->string('name');
+            $table->string('name')->unique();
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');


### PR DESCRIPTION
Closes #39 - Añadiendo creación del perfil cuando se registra un usuario en la aplicación utilizando la funcionalidad incorporada por el paquete Laravel Fortify de Jetstream. Se añade restricción unique al nombre del usuario para emplearlo tranquilamente como slug en la url para la página principal del usuario concreto y evitar duplicidades. Se añade la verificación en la creación para tal efecto.