### PR TITLE
(R41) Eliminar cuenta.

### DIFF
--- a/app/Actions/Jetstream/DeleteUser.php
+++ b/app/Actions/Jetstream/DeleteUser.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Jetstream;
 
+use App\Models\Profile;
 use Laravel\Jetstream\Contracts\DeletesUsers;
 
 class DeleteUser implements DeletesUsers
@@ -14,8 +15,12 @@ class DeleteUser implements DeletesUsers
      */
     public function delete($user)
     {
-        $user->deleteProfilePhoto();
-        $user->tokens->each->delete();
+        $profile = Profile::find($user->id);
+        $profile->is_deleted = true;
+        $profile->updated_at = now();
+        $profile->save();
+        //$user->deleteProfilePhoto();
+        //$user->tokens->each->delete();
         $user->delete();
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,18 +5,18 @@ namespace App\Models;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class User extends Authenticatable implements MustVerifyEmail
 {
     use HasApiTokens, HasFactory, HasProfilePhoto, Notifiable,
-        TwoFactorAuthenticatable, SoftDeletes, HasRoles;
+        TwoFactorAuthenticatable, HasRoles, SoftDeletes;
 
     /**
      * The attributes that are mass assignable.


### PR DESCRIPTION
Closes #41 - Añadiendo trait SoftDeletes al modelo User y realizando las modificaciones oportunas en la funcionalidad DeleteUser de Jetstream. El enfoque es que cuando se elimina una cuenta, se restringe el acceso y los datos del usuario no son visibles, pero el registro se mantiene el tiempo legal exigido. El borrado definitivo se implementará en el R69 - Automatización del mantenimiento mediante el uso de Task Scheduler.