### PR TITLE
56 r56 subir de nivel

### DIFF
--- a/app/Http/Controllers/ChallengeController.php
+++ b/app/Http/Controllers/ChallengeController.php
@@ -11,6 +11,7 @@ use App\Models\Mode;
 use App\Models\Profile;
 use App\Models\Score;
 use App\Models\User;
+use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
@@ -264,17 +265,17 @@ class ChallengeController extends Controller
 
             if ($this->checkTestResult($testResult)) {
 
-                $user = User::find(Auth::user()->id);
+                $profile = Auth::user()->profile;
 
-                if (!$user->passedKatas()->get()->contains($kata->id)) {
+                if (!$profile->passedKatas()->get()->contains($kata->id)) {
 
-                    $profile = $user->profile;
-                    $profile->passedKata()->attach($kata->id, [
+                    $profile->passedKatas()->attach($kata->id, [
                         'code' => $code,
                     ]);
 
                     $profile->exp = Score::where('denomination', 'training')
                         ->first()->points;
+                    $profile->save();
 
                     // crea variables con valores para modal.
                 }
@@ -345,7 +346,7 @@ class ChallengeController extends Controller
      */
     protected function checkTestResult(array $testResult)
     {
-        return substr( $testResult[count($testResult) - 1], 0, 2) === 'OK';
+        return substr($testResult[count($testResult) - 1], 0, 2) === 'OK';
     }
 
     /**

--- a/app/Http/Controllers/ChallengeController.php
+++ b/app/Http/Controllers/ChallengeController.php
@@ -218,6 +218,7 @@ class ChallengeController extends Controller
             'challenge' => $challenge,
             'owner' => $challenge->katas()->first()->owner->user,
             'signature' => $challenge->katas()->first()->signature,
+            'score' => Score::where('denomination', 'training')->first()->points,
         ]);
     }
 
@@ -269,18 +270,18 @@ class ChallengeController extends Controller
 
                 // If the user not passed the kata previously sum exp
                 // and save the solution.
-                if (!$profile->passedKatas()->get()->contains($kata->id)) {
+                // if (!$profile->passedKatas()->get()->contains($kata->id)) {
 
-                    $profile->passedKatas()->attach($kata->id, [
-                        'code' => $code,
-                    ]);
+                //     $profile->passedKatas()->attach($kata->id, [
+                //         'code' => $code,
+                //     ]);
 
-                    $profile->exp = Score::where('denomination', 'training')
-                        ->first()->points;
-                    $profile->save();
+                //     $profile->exp = Score::where('denomination', 'training')
+                //         ->first()->points;
+                //     $profile->save();
 
-                    // crea variables con valores para modal.
-                }
+                //     // crea variables con valores para modal.
+                // }
 
 
                 $returnHTML = view('includes.katapanel', [

--- a/app/Http/Controllers/ChallengeController.php
+++ b/app/Http/Controllers/ChallengeController.php
@@ -267,6 +267,8 @@ class ChallengeController extends Controller
 
                 $profile = Auth::user()->profile;
 
+                // If the user not passed the kata previously sum exp
+                // and save the solution.
                 if (!$profile->passedKatas()->get()->contains($kata->id)) {
 
                     $profile->passedKatas()->attach($kata->id, [
@@ -290,6 +292,7 @@ class ChallengeController extends Controller
                 return response()->json([
                     'success' => true,
                     'message' => $returnHTML,
+                    'progressbar' => $profile->getProfileProgress() . '%',
                 ]);
             }
 

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -130,7 +130,8 @@ class Profile extends Model
 
         $current_rank = $this->rank;
 
-        $next_rank = Rank::where('id', '>', $current_rank->id)->orderBy('id')->first();
+        $next_rank = Rank::where('id', '>', $current_rank->id)
+            ->orderBy('id')->first();
 
         if ($next_rank && $this->exp >= $current_rank->level_up) {
             $this->attributes['rank_id'] = $next_rank->id;

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -118,6 +118,26 @@ class Profile extends Model
     }
 
     /**
+     * Exp Attribute Mutator Method for set the level_up, under the hood,
+     * the user rank if the exp earned overtake the level_up attribute.
+     *
+     * @param int $exp
+     * @return void
+     */
+    public function setExpAttribute(int $exp): void
+    {
+        $this->attributes['exp'] += $exp;
+
+        $current_rank = $this->rank;
+
+        $next_rank = Rank::where('id', '>', $current_rank->id)->orderBy('id')->first();
+
+        if ($next_rank && $this->exp >= $current_rank->level_up) {
+            $this->attributes['rank_id'] = $next_rank->id;
+        }
+    }
+
+    /**
      * This determines the solutions of the profile.
      */
     public function solutions(): HasMany
@@ -391,12 +411,21 @@ class Profile extends Model
         }
     }
 
+    /**
+     * Get the value for the progress bar of the user.
+     */
     public function getProfileProgress()
     {
         $lastLevelUp = $this->rank->id === 1 ? 0 : Rank::find($this->rank_id - 1)->level_up;
         $actualLevelUp = $this->rank->level_up;
 
         $progress = ($this->exp - $lastLevelUp) / ($actualLevelUp - $lastLevelUp) * 100;
+
+        $previousRank = Rank::where('id', '<', $this->rank_id)->orderBy('id')->first();
+
+        if ($progress === $previousRank->level_up) {
+            $progress = 0;
+        }
 
         if (Rank::all()->count() === $this->rank_id
             && $this->exp > $this->rank->level_up

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -423,7 +423,7 @@ class Profile extends Model
 
         $previousRank = Rank::where('id', '<', $this->rank_id)->orderBy('id')->first();
 
-        if ($progress === $previousRank->level_up) {
+        if ($progress === $previousRank?->level_up) {
             $progress = 0;
         }
 

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -465,4 +465,9 @@
         @apply border border-slate-300 dark:border-slate-800/70 rounded-lg shadow-lg bg-slate-200/70 dark:bg-slate-700/70
                col-span-12 lg:col-span-4 min-h-[380px];
     }
+
+    .cross-menu {
+        @apply w-10 absolute top-2 right-2 text-center text-3xl text-slate-400 cursor-pointer transition-all duration-300
+               hover:text-slate-800 dark:hover:text-slate-100;
+    }
 }

--- a/resources/js/codekata.js
+++ b/resources/js/codekata.js
@@ -79,7 +79,7 @@ function checkCode()
         checkBTN.classList.add('active:translate-y-1');
 
         if (response.data.success) {
-            alert('show the modal');
+            $modals.show('passedkata-modal');
             errorPanel.innerHTML = response.data.message;
             document.getElementById('sidebar_progress-bar')
                 .style.width = response.data.progressbar;

--- a/resources/js/codekata.js
+++ b/resources/js/codekata.js
@@ -81,6 +81,8 @@ function checkCode()
         if (response.data.success) {
             alert('show the modal');
             errorPanel.innerHTML = response.data.message;
+            document.getElementById('sidebar_progress-bar')
+                .style.width = response.data.progressbar;
         } else {
             $flash.show('verifycode', 'error', response.data.flash);
             errorPanel.innerHTML = response.data.message;

--- a/resources/views/components/layout/modal.blade.php
+++ b/resources/views/components/layout/modal.blade.php
@@ -74,6 +74,7 @@
         x-transition:leave="ease-in duration-200"
         x-transition:leave-start="opacity-100"
         x-transition:leave-end="opacity-0"
+        @click.away ="show = false"
     >
         <div class="flex flex-col justify-evenly min-h-[300px] sm:h-full">
             <header>

--- a/resources/views/components/layout/progress-bar.blade.php
+++ b/resources/views/components/layout/progress-bar.blade.php
@@ -11,20 +11,27 @@
     $textSize = $sidebar ? 'text-sm' : 'text-md';
     $progress = $progress ?: auth()->user()->profile->getProfileProgress();
 
-    if (!$progress) {
+    if ($sidebar && !$progress) {
 
-        // $profile = auth()->user()->profile;
+        $profile = auth()->user()->profile;
 
-        // $lastLevelUp = $profile->rank->id === 1 ? 0 : App\Models\Rank::find($profile->rank_id - 1)->level_up;
-        // $actualLevelUp = $profile->rank->level_up;
+        $lastLevelUp = $profile->rank->id === 1 ? 0 : App\Models\Rank::find($profile->rank_id - 1)->level_up;
+        $actualLevelUp = $profile->rank->level_up;
 
-        // $progress = ($profile->exp - $lastLevelUp) / ($actualLevelUp - $lastLevelUp) * 100;
+        $progress = ($profile->exp - $lastLevelUp) / ($actualLevelUp - $lastLevelUp) * 100;
 
-        // if (App\Models\Rank::all()->count() === $profile->rank_id
-        //     && $profile->exp > $profile->rank->level_up
-        // ) {
-        //     $progress = 100;
-        // }
+        $previousRank = App\Models\Rank::where('id', '<', auth()->user()->profile->rank_id)->orderBy('id')->first();
+
+        if ($progress === $previousRank->level_up) {
+            $progress = 0;
+        }
+
+        if (App\Models\Rank::all()->count() === $profile->rank_id
+            && $profile->exp > $profile->rank->level_up
+        ) {
+            $progress = 100;
+        }
+
     }
 
 @endphp

--- a/resources/views/components/layout/progress-bar.blade.php
+++ b/resources/views/components/layout/progress-bar.blade.php
@@ -22,7 +22,7 @@
 
         $previousRank = App\Models\Rank::where('id', '<', auth()->user()->profile->rank_id)->orderBy('id')->first();
 
-        if ($progress === $previousRank->level_up) {
+        if ($progress === $previousRank?->level_up) {
             $progress = 0;
         }
 

--- a/resources/views/components/layout/progress-bar.blade.php
+++ b/resources/views/components/layout/progress-bar.blade.php
@@ -7,6 +7,7 @@
 
 @php
     $sidebar = $sidebar ?? false;
+    $id = $sidebar ? 'sidebar_progress-bar' : '';
     $bgColor = $sidebar ? 'dark:bg-gray-700/40' : 'dark:bg-gray-900/40';
     $textSize = $sidebar ? 'text-sm' : 'text-md';
     $progress = $progress ?: auth()->user()->profile->getProfileProgress();
@@ -44,7 +45,7 @@
     <div class="w-full mt-2 rounded-md bg-gray-900/10 {{ $bgColor }} saturate-150"
          style="height: {{ $size }}px"
     >
-        <div style="width: {{ $progress }}%" class="h-full bg-green-600 dark:bg-[#0bec7c]
+        <div id="{{$id}}" style="width: {{ $progress }}%" class="h-full bg-green-600 dark:bg-[#0bec7c]
                     animation-progress-bar rounded-md transition-all duration-500
                     dark:shadow-outter-md dark:shadow-green-400"
         ></div>

--- a/resources/views/components/layout/searcher.blade.php
+++ b/resources/views/components/layout/searcher.blade.php
@@ -30,7 +30,7 @@
                     .catch(error => console.log(error));
                 "
             />
-            <span class="w-10 absolute top-[3px] right-1 text-center text-3xl text-slate-400 cursor-pointer trasition-all duration-300 hover:text-slate-700"
+            <span class="w-10 absolute top-[3px] right-1 text-center text-3xl text-slate-400 cursor-pointer transition-all duration-300 hover:text-slate-700"
                   x-show="write"
                   x-on:click.prevent="
                     write = false;

--- a/resources/views/components/layout/sidebar-content.blade.php
+++ b/resources/views/components/layout/sidebar-content.blade.php
@@ -1,6 +1,6 @@
 <div>
     <div class="w-full pb-4 px-1 text-gray-700 dark:text-slate-200">
-        <x-layout.progress-bar size="4" title="Rank Progress" :sidebar="true" />
+        <x-layout.progress-bar size="4" title="Rank {{ ucwords(auth()->user()->profile->rank->name) }} Progress" :sidebar="true" />
     </div>
 
     <x-layout.dropdown-separator />

--- a/resources/views/katas/main-page.blade.php
+++ b/resources/views/katas/main-page.blade.php
@@ -136,6 +136,9 @@
                     <div class="py-4 text-center">
                         Challenge Complete!!
                     </div>
+                    <div class="cross-menu" @click.prevent="show = false">
+                        &times;
+                    </div>
                 </x-slot>
 
                 <x-slot name="body">
@@ -184,13 +187,23 @@
                             >
                         </div>
                     </div>
-                    <x-jet-button @click.prevent="">
-                        Next Challenge
-                    </x-jet-button>
+                    <form action="{{ route('katas.next') }}" method="get">
+                        <x-jet-button>
+                            Next Challenge
+                        </x-jet-button>
+                    </form>
+
                 </x-slot>
             </x-layout.modal>
 
             <x-layout.dinamicflash type="error" name="verifycode"></x-layout.dinamicflash>
+
+            @if (session()->has('syncStatus'))
+                <x-layout.flash type="{{ session('syncStatus') }}">
+                    {{ session('syncMessage') }}
+                </x-layout.flash>
+            @endif
+
         </main>
         <style>
             .ace_active-line {

--- a/resources/views/katas/main-page.blade.php
+++ b/resources/views/katas/main-page.blade.php
@@ -128,6 +128,67 @@
                     </section>
                 </div>
             </div>
+            <x-layout.modal name="passedkata-modal" maxWidth="2xl">
+                <x-slot name="title">
+                    <div class="text-3xl text-center text-violet-600 dark:text-tomato tracking-wider">
+                        {{ __('Congratulations!!!') }}
+                    </div>
+                    <div class="py-4 text-center">
+                        Challenge Complete!!
+                    </div>
+                </x-slot>
+
+                <x-slot name="body">
+                    @if (auth()->user()->profile->passedKatas->contains($challenge->katas->first()->id))
+                        <div class="w-full p-10 text-center text-slate-900">
+                            <span class="text-2xl dark:text-slate-100">You passed this Challenge Previously.</span>
+                        </div>
+                    @else
+                        <div class="w-full p-10 text-center text-slate-900">
+                            <span class="text-6xl text-slate-100">{{ $score }}</span><span class="text-slate-100 text-4xl px-2">EXP</span>
+                        </div>
+                        <div class="w-full flex flex-row justify-center items-center p-10">
+                            <div class="w-11/12">
+                                <x-layout.progress-bar :sidebar="true" size="5" title="" />
+                            </div>
+                        </div>
+                    @endif
+
+
+                </x-slot>
+
+                @php
+                    $isFav = auth()->user()->profile->favorites()->exists($challenge->katas->first()->id)
+                @endphp
+
+                <x-slot name="footer">
+                    <div class="w-1/2 flex justify-between">
+                        <div class="w-16 h-16">
+                            <img
+                                src="
+                                    @if ($isFav)
+                                        https://s3.eu-south-2.amazonaws.com/katawars.es/app/icons/favoritos2.png
+                                    @else
+                                        https://s3.eu-south-2.amazonaws.com/katawars.es/app/icons/favoritos1.png
+                                    @endif
+                                "
+                                x-ref="imagemarker"
+                                x-on:click="
+                                    if ($event.target.src === $katawars.S3.icons.favoritesOn) {
+                                        $event.target.src = $katawars.S3.icons.favoritesOff;
+                                    } else {
+                                        $event.target.src = $katawars.S3.icons.favoritesOn;
+                                    }
+                                "
+                                class="cursor-pointer"
+                            >
+                        </div>
+                    </div>
+                    <x-jet-button @click.prevent="">
+                        Next Challenge
+                    </x-jet-button>
+                </x-slot>
+            </x-layout.modal>
 
             <x-layout.dinamicflash type="error" name="verifycode"></x-layout.dinamicflash>
         </main>

--- a/resources/views/katas/main-page.blade.php
+++ b/resources/views/katas/main-page.blade.php
@@ -2,7 +2,7 @@
     <x-layout.wrapped-main-section>
 
         <main
-            x-data="{instructions: false, code: true, resources: false, solutions: false}"
+            x-data="{instructions: true, code: false, resources: false, solutions: false}"
             class="sm:mt-8 grid grid-flow-row sm:card-panel"
         >
             <nav class="grid grid-flow-col grid-cols-12 shadow-xl relative overflow-hidden dark:text-slate-200">

--- a/routes/web.php
+++ b/routes/web.php
@@ -93,6 +93,9 @@ Route::middleware([
     Route::get('/dojo', [ProfileController::class, 'showDojo'])
         ->name('dojo.index');
 
+    Route::get('/katas/next', [ChallengeController::class, 'showNextChallenge'])
+        ->name('katas.next');
+
     Route::get('/katas/{slug}', [ChallengeController::class, 'showKataMainPage'])
         ->name('katas.main-page');
 


### PR DESCRIPTION
Closes #56 - Se implementa funcionalidad para manejar las subidas de nivel de los usuarios cuando alcanzan un determinado nivel de experiencia acumulado. Se implementa método mutador setExpAttribute() sobre el modelo Profile, que permite que cada vez que el atributo exp cambie cuando se le suman puntos, haga una comprobación para verificar si los puntos actuales han igualado o superado al atribute level_up del modelo Rank. Se controla también que tras superar los retos sólo sume puntos la primera vez que el usuario valide el reto, así cómo el código que se guarda sólo es el primero. Se implementan mejores a nivel de diseño y reactividad como la actualización automática del progress bar del hub lateral, así como se introduce una nueva condición para que cuando suba de nivel la barra de progreso se reinicialice. Se introduce el botón de cierre como cruz en el modal para mostrar que se ha superado el reto. Se implementa en el modal la funcionalidad de Next Challenge, que llama a un método del controlador para que busque si hay disponible otro reto para el usuario de manera aleatoria. Sino devuelve flash indicando que ha superado todos los retos.