### PR TITLE
58 r58 guardar favoritos

### DIFF
--- a/app/CustomClasses/CircularCollection.php
+++ b/app/CustomClasses/CircularCollection.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\CustomClasses;
+
+use Illuminate\Support\Facades\Facade;
+use InvalidArgumentException;
+
+class CircularCollection extends Facade
+{
+    /**
+     * Contains the collection passed.
+     */
+    protected static $collection;
+
+
+    /**
+     * Override method to declare the S3 Facade.
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'CircularCollection';
+    }
+
+    /**
+     * Get CircularCollection class name.
+     */
+    public static function getClassName()
+    {
+        return self::class;
+    }
+
+    /**
+     * Create the collection with sort by id.
+     */
+    public static function make($collection)
+    {
+        self::$collection = $collection->sortBy('id');
+
+        return new static;
+    }
+
+    /**
+     * Counts the number of elements in the collection.
+     */
+    public function count()
+    {
+        return count(self::$collection);
+    }
+
+    /**
+     * Get an model or return all the registers in collection.
+     */
+    public function get($element = null)
+    {
+        $class = self::$collection[0]->first()::class;
+
+        if ($element instanceof $class || !$element) {
+            return $element
+            ? self::$collection->firstWhere('id', $element->id)
+            : collect(self::$collection);
+        } else {
+            throw new InvalidArgumentException('The argument#1 must be a instance of ' . $class);
+        }
+    }
+
+    /**
+     * Get the first element in the collection.
+     */
+    public function first()
+    {
+        return self::$collection[0];
+    }
+
+    /**
+     * Get the last element in the collection.
+     */
+    public function last()
+    {
+        return self::$collection[self::$collection->count() - 1];
+    }
+
+    /**
+     * Get the next element for a passed element.
+     * If the index is consumed return the first.
+     */
+    public function next($element)
+    {
+       $index = self::$collection->search($element);
+       return self::$collection->get(($index + 1) % self::$collection->count());
+    }
+
+    /**
+     * Get the previous element for a passed element.
+     * If the index is less than first element in the collection
+     * return the last.
+     */
+    public function previous($element)
+    {
+        $index = self::$collection->search($element);
+        return self::$collection->get(
+            ($index - 1 + self::$collection->count()) % self::$collection->count()
+        );
+    }
+}

--- a/app/Http/Controllers/FavoritesController.php
+++ b/app/Http/Controllers/FavoritesController.php
@@ -94,11 +94,20 @@ class FavoritesController extends Controller
 
         } else {
 
-            Favorite::create([
-                'profile_id' => Auth::user()->profile->id,
+            $profile = Auth::user()->profile;
+
+            $favorite = Favorite::create([
+                'profile_id' => $profile->id,
                 'solution_id' => $solution->id,
                 'is_active' => true,
             ]);
+
+            // Generate profile record fro the score type.
+            if ($favorite->createScoreRecord($profile->id)) {
+                // Assign Score for the owner of resource.
+                $favorite->assignScore();
+            }
+
         }
 
         return response()->json([

--- a/app/Http/Controllers/FavoritesController.php
+++ b/app/Http/Controllers/FavoritesController.php
@@ -4,9 +4,12 @@ namespace App\Http\Controllers;
 
 use App\Models\Favorite;
 use App\Models\Kata;
+use App\Models\Profile;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 
 class FavoritesController extends Controller
 {
@@ -155,8 +158,29 @@ class FavoritesController extends Controller
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id)
+    public function destroy(Request $request, $id)
     {
-        //
+        $request->validate([
+            'id' => ['integer'],
+        ]);
+
+        if (request()->ajax()) {
+
+            $favorites = Auth::user()->profile->favorites();
+
+            $favorite = $favorites->where('id', $id)
+                ->firstOrFail();
+            $favorite->delete();
+
+            return response()->json(
+                [
+                    'success' => true,
+                    'totalfavorites' => Auth::user()->profile->favorites()
+                        ->count(),
+                ]
+            );
+        }
+
+        return redirect()->back();
     }
 }

--- a/app/Http/Controllers/FavoritesController.php
+++ b/app/Http/Controllers/FavoritesController.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+
+class FavoritesController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        $request->validate([
+            'ord' => ['string', 'max:10'],
+        ]);
+
+        $favoritesKatas = Auth::user()->profile->favorites();
+
+        if ($request->ajax()) {
+
+            $favoritesKatas = $favoritesKatas->orderBy(
+                'id',
+                $request->query('sort'),
+            )->get();
+
+            $returnHTML = view('includes.favorites', [
+                'favoritesKatas' => $favoritesKatas
+            ])->render();
+
+            return response()->json([
+                'success' => true,
+                'html' => $returnHTML,
+            ]);
+        }
+
+        $lastUpdated = Auth::user()->profile->favorites()
+            ->orderBy('created_at', 'desc')
+            ?->first()
+            ?->created_at;
+
+        if ($lastUpdated) {
+            $lastUpdated = $lastUpdated->diffForHumans(now());
+            if ($lastUpdated === '1 day before') $lastUpdated = 'yesterday';
+
+            if (Str::of($lastUpdated)->contains(['hour','minute', 'second'])) {
+                $lastUpdated = 'today';
+            }
+        }
+
+        return view('katas.favorites', [
+            'favoritesKatas' => $favoritesKatas,
+            'lastUpdated' => $lastUpdated,
+            'totalFavorites' => Auth::user()->profile->favorites()->count(),
+        ]);
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/FavoritesController.php
+++ b/app/Http/Controllers/FavoritesController.php
@@ -22,17 +22,17 @@ class FavoritesController extends Controller
             'ord' => ['string', 'max:10'],
         ]);
 
-        $favoritesKatas = Auth::user()->profile->favorites();
+        $favorites = Auth::user()->profile->favorites();
 
         if ($request->ajax()) {
 
-            $favoritesKatas = $favoritesKatas->orderBy(
+            $favorites = $favorites->orderBy(
                 'id',
-                $request->query('sort'),
+                $request->query('ord'),
             )->get();
 
             $returnHTML = view('includes.favorites', [
-                'favoritesKatas' => $favoritesKatas
+                'favorites' => $favorites
             ])->render();
 
             return response()->json([
@@ -56,7 +56,7 @@ class FavoritesController extends Controller
         }
 
         return view('katas.favorites', [
-            'favorites' => $favoritesKatas->get(),
+            'favorites' => $favorites->get(),
             'lastUpdated' => $lastUpdated,
             'totalFavorites' => Auth::user()->profile->favorites()->count(),
         ]);

--- a/app/Http/Controllers/FavoritesController.php
+++ b/app/Http/Controllers/FavoritesController.php
@@ -2,9 +2,12 @@
 
 namespace App\Http\Controllers;
 
+use App\Jobs\FavoriteJob;
+use App\Mail\AddFavorite;
 use App\Models\Favorite;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
 
 class FavoritesController extends Controller
@@ -106,8 +109,9 @@ class FavoritesController extends Controller
             if ($favorite->createScoreRecord($profile->id)) {
                 // Assign Score for the owner of resource.
                 $favorite->assignScore();
+                FavoriteJob::dispatch($favorite)
+                    ->onQueue('sendMailQueue');
             }
-
         }
 
         return response()->json([

--- a/app/Http/Controllers/SavedKatasController.php
+++ b/app/Http/Controllers/SavedKatasController.php
@@ -100,8 +100,12 @@ class SavedKatasController extends Controller
             $savedKatas->detach($kata->id);
         } else {
 
-            $num_orden = $savedKatas->orderByPivot('num_orden', 'desc')
-                ->first()->pivot->num_orden + 1;
+            if ($savedKatas->count()) {
+                $num_orden = $savedKatas->orderByPivot('num_orden', 'desc')
+                    ->first()->pivot->num_orden + 1;
+            } else {
+                $num_orden = 1;
+            }
 
             $savedKatas->attach($kata->id, [
                 'num_orden' => $num_orden,
@@ -231,11 +235,15 @@ class SavedKatasController extends Controller
 
             Profile::getsavedKatas()->detach($id);
 
+            $totalSavedKatas = auth()->user()->profile->savedKatas()->count();
+
+            if (!$totalSavedKatas) $returnHTML = '<h1 class="flex items-center text-lg dark:text-slate-100 font-semibold justify-center">Your list its empty.</h1>';
+
             return response()->json(
                 [
                     'success' => true,
                     'html' => $returnHTML,
-                    'totalSavedKatas' => auth()->user()->profile->savedKatas()->count(),
+                    'totalSavedKatas' => $totalSavedKatas,
                 ]
             );
         }

--- a/app/Http/Controllers/SavedKatasController.php
+++ b/app/Http/Controllers/SavedKatasController.php
@@ -37,9 +37,15 @@ class SavedKatasController extends Controller
 
         if ($request->ajax()) {
 
-            $returnHTML = view('includes.saved', [
-                'savedKatas' => $savedKatas
-            ])->render();
+            $numSavedKatas = Auth::user()->profile->savedKatas->count();
+
+            if ($numSavedKatas > self::PER_PAGE) {
+                $returnHTML = view('includes.saved', [
+                    'savedKatas' => $savedKatas
+                ])->render();
+            } else {
+                $returnHTML = '';
+            }
 
             return response()->json([
                 'success' => true,

--- a/app/Jobs/FavoriteJob.php
+++ b/app/Jobs/FavoriteJob.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Mail\AddFavorite;
+use App\Models\Favorite;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Mail;
+
+class FavoriteJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $favorite;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct($favorite)
+    {
+        $this->favorite = $favorite;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        Mail::send(new AddFavorite($this->favorite));
+    }
+}

--- a/app/Mail/AddFavorite.php
+++ b/app/Mail/AddFavorite.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Favorite;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class AddFavorite extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $user;
+    public $voterUsername;
+    public $score;
+    public $typeScore;
+    public $challenge;
+    public $url;
+
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($favorite)
+    {
+        $this->user = $favorite->solution->kata->owner->user;
+        $this->voterUsername = $favorite->profile->user->name;
+        $this->score = $favorite->scoreRecords->first()->score->points;
+        $this->typeScore = $favorite->scoreRecords->first()->score->type;
+        $this->challenge = $favorite->solution->kata->challenge->title;
+        $this->url = $favorite->solution->kata->challenge->url;
+    }
+
+    /**
+     * Get the message envelope.
+     *
+     * @return \Illuminate\Mail\Mailables\Envelope
+     */
+    public function envelope()
+    {
+        return new Envelope(
+            to: [$this->user->name => $this->user->email],
+            subject: 'Your resources has been voted!',
+        );
+    }
+
+    /**
+     * Get the message content definition.
+     *
+     * @return \Illuminate\Mail\Mailables\Content
+     */
+    public function content()
+    {
+        return new Content(
+            view: 'mail.favorite',
+            with: [
+                'greeting' => "Dear " . $this->user->name . "!",
+                'url' => $this->url,
+                'challenge' => $this->challenge,
+                'score' => $this->score,
+                'typeScore' => $this->typeScore,
+                'voterUsername' => $this->voterUsername,
+                'introLines' => [
+                    "You have won:"
+                ],
+                'outroLines' => [
+                    'Thanks you so much for give content to our website.',
+                    'Continue for this path and enjoy coding!',
+                    'Regards,',
+                    'Katawars.',
+                ],
+                'slogan' => 'Improve your coding skills with less effort, in less time.',
+            ],
+        );
+    }
+
+    /**
+     * Get the attachments for the message.
+     *
+     * @return array
+     */
+    public function attachments()
+    {
+        return [];
+    }
+}

--- a/app/Models/Challenge.php
+++ b/app/Models/Challenge.php
@@ -29,6 +29,14 @@ class Challenge extends Model
     ];
 
     /**
+     * Laravel Scout only indexes the challenges of training mode in Algolia.
+     */
+    public function shouldBeSearchable()
+    {
+        return $this->katas()->where('mode_id', 1)->exists();
+    }
+
+    /**
      * Get the indexable data array for the model.
      *
      * @return array

--- a/app/Models/Favorite.php
+++ b/app/Models/Favorite.php
@@ -16,7 +16,7 @@ class Favorite extends Model
      *
      * @var string[]
      */
-    protected $fillable = ['profile_id', 'solution_id'];
+    protected $fillable = ['profile_id', 'solution_id', 'is_active'];
 
     /**
      * This determine which profile is associated with a favorite.

--- a/app/Models/Favorite.php
+++ b/app/Models/Favorite.php
@@ -33,4 +33,13 @@ class Favorite extends Model
     {
         return $this->belongsTo(Solution::class, 'solution_id', 'id', 'solutions');
     }
+
+    /**
+     * This determines which score record was created when the profile
+     * added the resource to his favorite list.
+     */
+    public function scoreRecords()
+    {
+        return $this->morphMany(ScoreRecord::class, 'scoreables');
+    }
 }

--- a/app/Providers/CircularCollectionServiceProvider.php
+++ b/app/Providers/CircularCollectionServiceProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Providers;
+
+use App\CustomClasses\CircularCollection;
+use Illuminate\Support\ServiceProvider;
+
+class CircularCollectionServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->bind('CircularCollection', function($app) {
+            return new CircularCollection;
+        });
+    }
+
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
+}

--- a/app/Traits/Scoreable.php
+++ b/app/Traits/Scoreable.php
@@ -2,24 +2,26 @@
 
 namespace App\Traits;
 
+use App\Models\Favorite;
 use App\Models\Kata;
 use App\Models\Profile;
+use App\Models\Resource;
 use App\Models\Score;
 use App\Models\ScoreRecord;
-use Illuminate\Database\Eloquent\Collection;
+use App\Models\Solution;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 trait Scoreable
 {
     private $denominations = [
-        'App\Models\Solution' => 'likes',
-        'App\Models\Resource' => 'likes',
-        'App\Models\Favorite' => 'add-favorites',
+        'App\Models\Solution' => 'like',
+        'App\Models\Resource' => 'like',
+        'App\Models\Favorite' => 'add favorites',
     ];
 
     /**
-     * Get all punctuations for a related Punctuable model.
+     * Get all punctuations for a related scoreable model.
      */
     public function scores(): MorphMany
     {
@@ -27,7 +29,7 @@ trait Scoreable
     }
 
     /**
-     * Get all registers that have been punctuated by the profiles.
+     * Get all registers that have been scored by the profiles.
      */
     public function scoredByProfiles(): MorphToMany
     {
@@ -37,7 +39,7 @@ trait Scoreable
     }
 
     /**
-     * Set the punctuation for a punctuable interaction.
+     * Set the punctuation for a scoreable interaction.
      * Return true if the operation was succesfull, false otherwise.
      */
     public function createScoreRecord(int $voterID = null)
@@ -62,7 +64,7 @@ trait Scoreable
      * Assign the score to the owner of the entity on which the interaction
      * is performed.
      */
-    public function assignScore(): void
+    public function assignScore(): bool
     {
         $profile = Profile::find($this->selectForeignKey());
         $profile->honor += Score::where(
@@ -72,6 +74,8 @@ trait Scoreable
         ->first()
         ->points;
         $profile->save();
+
+        return true;
     }
 
     /**
@@ -96,7 +100,7 @@ trait Scoreable
     /**
      * Check if the passed voter profile exist in database.
      */
-    private function profileExist(int $voterID): bool
+    public function profileExist(int $voterID): bool
     {
         return Profile::pluck('id')->contains($voterID);
     }
@@ -104,10 +108,12 @@ trait Scoreable
     /**
      * This determines which identifier select depending on the model used.
      */
-    private function selectForeignKey(): int
+    public function selectForeignKey()
     {
-        return ($this::class === Kata::class)
-            ? $this->owner_id
-            : $this->profile_id;
+        return [
+            Favorite::class => $this->solution->kata->owner_id,
+            Resource::class => $this->profile_id,
+            Solution::class => $this->profile_id,
+        ][$this::class];
     }
 }

--- a/app/Traits/Scoreable.php
+++ b/app/Traits/Scoreable.php
@@ -3,7 +3,6 @@
 namespace App\Traits;
 
 use App\Models\Favorite;
-use App\Models\Kata;
 use App\Models\Profile;
 use App\Models\Resource;
 use App\Models\Score;
@@ -11,6 +10,7 @@ use App\Models\ScoreRecord;
 use App\Models\Solution;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Support\Facades\Auth;
 
 trait Scoreable
 {
@@ -44,7 +44,7 @@ trait Scoreable
      */
     public function createScoreRecord(int $voterID = null)
     {
-        $voterID = $voterID ?? auth()->user()->id;
+        $voterID = $voterID ?? Auth::user()->profile->id;
 
         if ($this->scoredBy($voterID) || !$this->profileExist($voterID)
             || $voterID === $this->selectForeignKey() ) {

--- a/config/app.php
+++ b/config/app.php
@@ -199,6 +199,7 @@ return [
         App\Providers\JetstreamServiceProvider::class,
         App\Providers\S3ServiceProvider::class,
         App\Providers\SecurityFilterServiceProvider::class,
+        App\Providers\CircularCollectionServiceProvider::class,
 
     ],
 
@@ -218,6 +219,7 @@ return [
         'Redis' => Illuminate\Support\Facades\Redis::class,
         'S3' => App\CustomClasses\S3::class,
         'SecurityFilter' => App\CustomClasses\SecurityFilter::class,
+        'CircularCollection' => App\CustomClasses\CircularCollection::class,
     ])->toArray(),
 
 ];

--- a/database/migrations/2023_02_28_214657_create_favorites_table.php
+++ b/database/migrations/2023_02_28_214657_create_favorites_table.php
@@ -25,6 +25,7 @@ return new class extends Migration
                 ->cascadeOnDelete()->cascadeOnUpdate();
             $table->foreignId('solution_id')->constrained()
                 ->cascadeOnDelete()->cascadeOnUpdate();
+            $table->boolean('is_active');
             $table->timestamps();
             $table->unique(['profile_id', 'solution_id']);
         });

--- a/database/seeders/ChallengeSeeder.php
+++ b/database/seeders/ChallengeSeeder.php
@@ -1190,12 +1190,12 @@ class ChallengeSeeder extends Seeder
 
         // MCM
 
-        $slug = Str::slug('Least Common Divisor');
+        $slug = Str::slug('Least Common Multiple');
 
         $challenge = Challenge::create([
             'slug' => $slug,
             'url' => url("/katas/$slug"),
-            'title' => 'Calculate the Least Common Divisor',
+            'title' => 'Calculate the Least Common Multiple',
             'rank_id' => 3,
             'description' => <<<EOL
                 <p>Write a function named <code>mcm</code> that takes two arguments of type <code>int</code> named <code>a</code> and <code>b</code> and returns the least common multiple (LCM) of them. The LCM of two numbers is the smallest positive integer that is divisible by both numbers without leaving a remainder. For example, the LCM of 4 and 6 is 12.</p>

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -492,7 +492,7 @@
     }
 
     .cross-savedkata {
-        @apply w-6 h-6 absolute top-0 right-0 flex items-center justify-center text-xl rounded-lg bg-slate-300
+        @apply w-6 h-6 absolute top-1 right-0 flex items-center justify-center text-xl rounded-lg bg-slate-300
                dark:bg-slate-900/40 dark:hover:bg-rose-600 hover:bg-violet-600 hover:shadow-outter-sm text-slate-100
                hover:shadow-violet-600 dark:hover:shadow-outter-sm dark:hover:shadow-rose-600 hover:text-slate-100
                dark:text-slate-400 dark:hover:text-slate-100 cursor-pointer opacity-0 transform transition-all

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -85,6 +85,16 @@ window.$theme = {
     }
 }
 
+window.$progressbar = {
+    update(progress) {
+        window.dispatchEvent(
+            new CustomEvent('updateprogress', {
+                detail: progress,
+            })
+        );
+    }
+}
+
 window.$aux = {
     createElement(elem = null, attributes = {}, textNode = '') {
 

--- a/resources/js/codekata.js
+++ b/resources/js/codekata.js
@@ -81,7 +81,8 @@ function checkCode()
         if (response.data.success) {
             $modals.show('passedkata-modal');
             errorPanel.innerHTML = response.data.message;
-            document.getElementById('sidebar_progress-bar').style.width = response.data.progressbar;
+            $progressbar.update(response.data.$progressbar);
+
         } else {
             $flash.show('verifycode', 'error', response.data.flash);
             errorPanel.innerHTML = response.data.message;

--- a/resources/js/codekata.js
+++ b/resources/js/codekata.js
@@ -53,8 +53,6 @@ document.addEventListener('DOMContentLoaded', eDCL => {
         checkBTN.classList.remove('active:translate-y-1');
         checkCode();
     });
-
-
 });
 
 /**

--- a/resources/js/favorites.js
+++ b/resources/js/favorites.js
@@ -1,0 +1,59 @@
+
+const list = document.getElementById('list');
+
+if (list) {
+
+    list.addEventListener('click', (eClick) => {
+
+        if (['cross-savedkata', 'cross'].includes(eClick.target.classList[0])) {
+
+            let getID = {
+                'cross-savedkata': eClick.target.id,
+                'cross': eClick.target.parentNode.id,
+            }
+
+            let favoriteID = getID[eClick.target.classList[0]];
+
+            let favorite = [...list.querySelectorAll(".card-challenge")]
+                    .filter(elem => elem.id === favoriteID)
+                    .shift();
+
+            favorite.style.transition = '.3s';
+            favorite.style.overflow = 'hidden';
+            favorite.style.opacity = '0%';
+            favorite.style.padding = '0px';
+            favorite.style.height = '0px';
+
+            setTimeout(() => favorite.style.display = 'none', 300);
+
+            if (favoriteID) {
+                axios.delete('/favorites/' + favoriteID)
+                .then(response => {
+
+                    if (response.data.success) {
+                        let favorite = [...list.querySelectorAll(".card-challenge")]
+                            .filter(elem => elem.id === favoriteID)
+                            .shift();
+
+                        setTimeout(elem => {
+                            list.removeChild(favorite);
+                        }, 700);
+
+                        list.insertAdjacentHTML('beforeend', response.data.html);
+                        window.dispatchEvent(
+                            new CustomEvent('updatesaved', {
+                                detail: response.data.totalfavorites,
+                            })
+                        );
+                    }
+                })
+                .catch(error => console.log(error));
+            }
+
+        }
+    });
+}
+
+// Delete Favorites.
+
+

--- a/resources/js/favorites.js
+++ b/resources/js/favorites.js
@@ -35,12 +35,13 @@ if (list) {
                             .filter(elem => elem.id === favoriteID)
                             .shift();
 
-                        setTimeout(elem => {
+                        let timeout = setTimeout(elem => {
                             list.removeChild(favorite);
                         }, 700);
 
                         if (!response.data.totalfavorites) {
                             list.innerHTML = '<h1 class="flex items-center text-lg dark:text-slate-100 font-semibold justify-center">Your list its empty.</h1>';
+                            clearTimeout(timeout);
                         }
 
                         window.dispatchEvent(

--- a/resources/js/favorites.js
+++ b/resources/js/favorites.js
@@ -39,9 +39,12 @@ if (list) {
                             list.removeChild(favorite);
                         }, 700);
 
-                        list.insertAdjacentHTML('beforeend', response.data.html);
+                        if (!response.data.totalfavorites) {
+                            list.innerHTML = '<h1 class="flex items-center text-lg dark:text-slate-100 font-semibold justify-center">Your list its empty.</h1>';
+                        }
+
                         window.dispatchEvent(
-                            new CustomEvent('updatesaved', {
+                            new CustomEvent('updatefavorites', {
                                 detail: response.data.totalfavorites,
                             })
                         );
@@ -49,11 +52,6 @@ if (list) {
                 })
                 .catch(error => console.log(error));
             }
-
         }
     });
 }
-
-// Delete Favorites.
-
-

--- a/resources/js/savedkatas.js
+++ b/resources/js/savedkatas.js
@@ -1,123 +1,128 @@
 
    // Set sortable object with the list of saved katas.
    const list = document.getElementById('list');
-   Sortable.create(
-       list,
-       {
-           handle: '.handle',
-           animation: 500,
-           direction: 'vertical',
-       }
-   );
 
-   // Async Infinite Scroll
 
-   window.addEventListener('DOMContentLoaded', (eDCL) => {
-    window.addEventListener('scroll', (eScroll) => {
-        eScroll.stopImmediatePropagation();
+    if (list) {
 
-        if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
+        Sortable.create(
+            list,
+            {
+                handle: '.handle',
+                animation: 500,
+                direction: 'vertical',
+            }
+        );
 
-            let url = window.location.href;
-            let nextCursor = list.querySelector('#next-cursor').innerHTML || null;
+        // Async Infinite Scroll
 
-            if (nextCursor) {
-                axios({
-                    method: 'get',
-                    url: url + '?cursor=' + nextCursor,
-                    responseType: 'json',
-                    data: {
-                        nextCursor: nextCursor,
+        window.addEventListener('DOMContentLoaded', (eDCL) => {
+            window.addEventListener('scroll', (eScroll) => {
+                eScroll.stopImmediatePropagation();
+
+                if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
+
+                    let url = window.location.href;
+                    let nextCursor = list.querySelector('#next-cursor').innerHTML || null;
+
+                    if (nextCursor) {
+                        axios({
+                            method: 'get',
+                            url: url + '?cursor=' + nextCursor,
+                            responseType: 'json',
+                            data: {
+                                nextCursor: nextCursor,
+                            }
+                        })
+                        .then(response => {
+                            if (response.data.success) {
+                                list.insertAdjacentHTML('beforeend', response.data.html);
+                                list.querySelector('#next-cursor').innerHTML = response.data.nextCursor;
+                            } else {
+                            console.log(response.data.nextCursor); // PENDIENTE ELIMINAR
+                            }
+                        })
+                        .catch(error => console.log(error));
                     }
-                })
+                }
+            })
+        });
+
+
+        // Actualización Orden Manual (Sortable).
+
+        let target;
+
+        list.addEventListener('drag', (eDrag) => {
+            target = eDrag.target.id;
+        });
+
+        list.addEventListener('drop', (eDrop) => {
+
+            let modifiedOrder = [...list.querySelectorAll('.card-challenge')].map((elem) => elem.id);
+
+            axios({
+                method: 'patch',
+                url: "/saved-katas/update",
+                responseType: 'json',
+                data: {
+                    modifiedOrder: modifiedOrder,
+                    target: target,
+                }
+            })
+            .then(response => (response.data.success)
+                ? console.log('Successful Update!')
+                : null
+            )
+            .catch(error => console.log(error));
+        });
+
+
+        // Delete Saved Kata.
+
+        list.addEventListener('click', (eClick) => {
+
+            let getID = {
+                'cross-savedkata': eClick.target.id,
+                'cross': eClick.target.parentNode.id,
+            }
+
+            let savedKataID = getID[eClick.target.classList[0]];
+
+            let savedKata = [...list.querySelectorAll(".card-challenge")]
+                    .filter(elem => elem.id === savedKataID)
+                    .shift();
+
+            savedKata.style.transition = '.3s';
+            savedKata.style.overflow = 'hidden';
+            savedKata.style.opacity = '0%';
+            savedKata.style.padding = '0px';
+            savedKata.style.height = '0px';
+
+            setTimeout(() => savedKata.style.display = 'none', 300);
+
+            if (savedKataID) {
+                axios.delete('/saved-katas/' + savedKataID)
                 .then(response => {
+
                     if (response.data.success) {
+                        let savedKata = [...list.querySelectorAll(".card-challenge")]
+                            .filter(elem => elem.id === savedKataID)
+                            .shift();
+
+                        setTimeout(elem => {
+                            list.removeChild(savedKata);
+                        }, 700);
+
                         list.insertAdjacentHTML('beforeend', response.data.html);
-                        list.querySelector('#next-cursor').innerHTML = response.data.nextCursor;
-                    } else {
-                       console.log(response.data.nextCursor); // PENDIENTE ELIMINAR
+                        window.dispatchEvent(
+                            new CustomEvent('updatesaved', {
+                                detail: response.data.totalSavedKatas,
+                            })
+                        );
                     }
                 })
                 .catch(error => console.log(error));
             }
-        }
-    })
-});
-
-
-// Actualización Orden Manual (Sortable).
-
-let target;
-
-list.addEventListener('drag', (eDrag) => {
-    target = eDrag.target.id;
-});
-
-list.addEventListener('drop', (eDrop) => {
-
-    let modifiedOrder = [...list.querySelectorAll('.card-challenge')].map((elem) => elem.id);
-
-    axios({
-        method: 'patch',
-        url: "/saved-katas/update",
-        responseType: 'json',
-        data: {
-            modifiedOrder: modifiedOrder,
-            target: target,
-        }
-    })
-    .then(response => (response.data.success)
-        ? console.log('Successful Update!')
-        : null
-    )
-    .catch(error => console.log(error));
-});
-
-
-// Delete Saved Kata.
-
-list.addEventListener('click', (eClick) => {
-
-    let getID = {
-        'cross-savedkata': eClick.target.id,
-        'cross': eClick.target.parentNode.id,
+        });
     }
-
-    let savedKataID = getID[eClick.target.classList[0]];
-
-    let savedKata = [...list.querySelectorAll(".card-challenge")]
-            .filter(elem => elem.id === savedKataID)
-            .shift();
-
-    savedKata.style.transition = '.3s';
-    savedKata.style.overflow = 'hidden';
-    savedKata.style.opacity = '0%';
-    savedKata.style.padding = '0px';
-    savedKata.style.height = '0px';
-
-    setTimeout(() => savedKata.style.display = 'none', 300);
-
-    if (savedKataID) {
-        axios.delete('/saved-katas/' + savedKataID)
-        .then(response => {
-
-            if (response.data.success) {
-                let savedKata = [...list.querySelectorAll(".card-challenge")]
-                    .filter(elem => elem.id === savedKataID)
-                    .shift();
-
-                setTimeout(elem => {
-                    list.removeChild(savedKata);
-                }, 700);
-
-                list.insertAdjacentHTML('beforeend', response.data.html);
-                window.dispatchEvent(
-                    new CustomEvent('updatesaved', {
-                        detail: response.data.totalSavedKatas,
-                    })
-                );
-            }
-        })
-        .catch(error => console.log(error));
-    }
-});

--- a/resources/views/challenges/index.blade.php
+++ b/resources/views/challenges/index.blade.php
@@ -136,7 +136,7 @@
                             <div class=" w-full flex flex-row justify-end gap-8 item-center">
                                 <x-layout.saved-marker :id="$challenge->katas->first()->id" />
                                     @if (auth()->user()->profile->passedKatas()->get()->contains($challenge->katas()->first()->id))
-                                        <x-layout.favorite-button size="md" />
+                                        <x-layout.favorite-button :id="$challenge->katas()->first()->id" size="md" />
                                     @endif
                             </div>
 

--- a/resources/views/challenges/index.blade.php
+++ b/resources/views/challenges/index.blade.php
@@ -133,7 +133,13 @@
                                 <x-utilities.rank size="4" :rank="$challenge->rank->name" />
                             </div>
 
-                            <x-layout.saved-marker :id="$challenge->katas->first()->id" />
+                            <div class=" w-full flex flex-row justify-end gap-8 item-center">
+                                <x-layout.saved-marker :id="$challenge->katas->first()->id" />
+                                    @if (auth()->user()->profile->passedKatas()->get()->contains($challenge->katas()->first()->id))
+                                        <x-layout.favorite-button size="md" />
+                                    @endif
+                            </div>
+
                         </div>
 
                         <div class="py-2">

--- a/resources/views/components/layout/favorite-button.blade.php
+++ b/resources/views/components/layout/favorite-button.blade.php
@@ -12,7 +12,7 @@
         '2xl' => 'w-20 h-20',
     ][$size ?? 'lg'];
 
-    $isFav = auth()->user()->profile->favorites()->get()->contains($id)
+    $isFav = auth()->user()->profile->solutions()->where('kata_id', $id)->first()->favorite;
 @endphp
 
 
@@ -34,7 +34,14 @@
                 } else {
                     $event.target.src = $katawars.S3.icons.favoritesOn;
                 }
-                console.log($event.target.id);
+
+                axios({
+                    method: 'put',
+                    url: '/favorites/' + $event.target.id,
+                    responseType: 'json',
+                })
+                .then(response => console.log(response.data.success))
+                .catch(errors => console.log(errors));
             "
             class="cursor-pointer"
         >

--- a/resources/views/components/layout/favorite-button.blade.php
+++ b/resources/views/components/layout/favorite-button.blade.php
@@ -16,7 +16,7 @@
 @endphp
 
 
-<div class="w-1/2 flex justify-between">
+<div class="flex justify-between items-center">
     <div class="{{ $size }}">
         <img
             src="

--- a/resources/views/components/layout/favorite-button.blade.php
+++ b/resources/views/components/layout/favorite-button.blade.php
@@ -14,7 +14,7 @@
 
     $isFav = auth()->user()->profile->solutions()
         ->where('kata_id', $id)->first()?->favorite
-        ->where('is_active', true)->count();
+        ?->where('is_active', true)?->count();
 @endphp
 
 

--- a/resources/views/components/layout/favorite-button.blade.php
+++ b/resources/views/components/layout/favorite-button.blade.php
@@ -12,7 +12,9 @@
         '2xl' => 'w-20 h-20',
     ][$size ?? 'lg'];
 
-    $isFav = auth()->user()->profile->solutions()->where('kata_id', $id)->first()->favorite;
+    $isFav = auth()->user()->profile->solutions()
+        ->where('kata_id', $id)->first()?->favorite
+        ->where('is_active', true)->count();
 @endphp
 
 

--- a/resources/views/components/layout/order-button.blade.php
+++ b/resources/views/components/layout/order-button.blade.php
@@ -1,6 +1,5 @@
 @props([
-    'routeAsc' => '',
-    'routeDesc' => '',
+    'route' => '',
 ])
 
 <div class="pb-8">
@@ -16,11 +15,41 @@
 
         <x-slot name="content">
             <div>
-                <x-jet-dropdown-link href="{{ $routeAsc }}?ord=asc" class="cursor-pointer">
+                <x-jet-dropdown-link :button="true"
+                    x-on:click="
+                        axios({
+                            method: 'get',
+                            url: '{{ $route }}?ord=asc',
+                            responseType: 'json',
+                        })
+                        .then(response => {
+                            if (response.data.success) {
+                                $refs.list.innerHTML = response.data.html;
+                            }
+                        })
+                        .catch(errors => console.log(errors));
+                    "
+                    class="cursor-pointer"
+                >
                     {{ __('Ascending (from less to more)') }}
                 </x-jet-dropdown-link>
 
-                <x-jet-dropdown-link href="{{ $routeDesc }}?ord=desc" class="cursor-pointer">
+                <x-jet-dropdown-link
+                    :button="true"
+                    x-on:click="
+                        axios({
+                            method: 'get',
+                            url: '{{ $route }}?ord=desc',
+                            responseType: 'json',
+                        })
+                        .then(response => {
+                            if (response.data.success) {
+                                $refs.list.innerHTML = response.data.html;
+                            }
+                        })
+                        .catch(errors => console.log(errors));
+                    "
+                    class="cursor-pointer">
                     {{ __('Descending (from more to less)') }}
                 </x-jet-dropdown-link>
             </div>

--- a/resources/views/components/layout/progress-bar.blade.php
+++ b/resources/views/components/layout/progress-bar.blade.php
@@ -45,9 +45,16 @@
     <div class="w-full mt-2 rounded-md bg-gray-900/10 {{ $bgColor }} saturate-150"
          style="height: {{ $size }}px"
     >
-        <div id="{{$id}}" style="width: {{ $progress }}%" class="h-full bg-green-600 dark:bg-[#0bec7c]
-                    animation-progress-bar rounded-md transition-all duration-500
-                    dark:shadow-outter-md dark:shadow-green-400"
+        <div
+            id="{{$id}}"
+            style="width: {{ $progress }}%"
+            class="h-full bg-green-600 dark:bg-[#0bec7c] animation-progress-bar rounded-md
+                   transition-all duration-500 dark:shadow-outter-md dark:shadow-green-400"
+            @updateprogress.window="
+                $el.width = $event.target.detail;
+                $el.classList.toggle('animation-progress-bar');
+                $el.classList.toggle('animation-progress-bar');
+            "
         ></div>
     </div>
 </div>

--- a/resources/views/components/layout/saved-marker.blade.php
+++ b/resources/views/components/layout/saved-marker.blade.php
@@ -5,7 +5,7 @@
 @endphp
 
 
-<div class="w-56 flex flex-row justify-end items-center" >
+<div class="flex flex-row justify-end items-center" >
     <img
         src="
         @if ($isSaved)

--- a/resources/views/components/layout/sidebar-content.blade.php
+++ b/resources/views/components/layout/sidebar-content.blade.php
@@ -44,7 +44,7 @@
         {{ __('Saved Katas') }}
     </x-jet-dropdown-link>
 
-    <x-jet-dropdown-link href="{{ route('dashboard') }}" class="text-md items-center">
+    <x-jet-dropdown-link href="{{ route('katas.favorites') }}" class="text-md items-center">
         <x-layout.dropdown-icon srcPath="favorites" class="mr-6" sidebar />
         {{ __('Favorites') }}
     </x-jet-dropdown-link>

--- a/resources/views/includes/challenges.blade.php
+++ b/resources/views/includes/challenges.blade.php
@@ -25,31 +25,11 @@
                 <x-utilities.rank :size="4" :rank="$challenge->rank->name"/>
             </div>
 
-            @php
-                $isSaved = auth()->user()->profile->savedKatas()->exists($challenge->katas->first()->id);
-            @endphp
-
-            <div class="w-56 flex flex-row justify-evenly items-center">
-                <div class="w-56 flex flex-row justify-end items-center" >
-                    <img
-                        src="
-                        @if ($isSaved)
-                            https://s3.eu-south-2.amazonaws.com/katawars.es/app/icons/marcador2.png
-                        @else
-                            https://s3.eu-south-2.amazonaws.com/katawars.es/app/icons/marcador1.png
-                        @endif"
-                        class="h-8 w-8 cursor-pointer"
-                        x-ref="imagemarker"
-                        x-on:click="
-                            if ($event.target.src === $katawars.S3.icons.markerOn) {
-                                $event.target.src = $katawars.S3.icons.markerOff;
-                            } else {
-                                $event.target.src = $katawars.S3.icons.markerOn;
-                            }
-                        "
-                    />
-
-                </div>
+            <div class=" w-full flex flex-row justify-end gap-8 item-center">
+                <x-layout.saved-marker :id="$challenge->katas->first()->id" />
+                    @if (auth()->user()->profile->passedKatas()->get()->contains($challenge->katas()->first()->id))
+                        <x-layout.favorite-button size="md" />
+                    @endif
             </div>
         </div>
 

--- a/resources/views/includes/challenges.blade.php
+++ b/resources/views/includes/challenges.blade.php
@@ -26,9 +26,12 @@
             </div>
 
             <div class=" w-full flex flex-row justify-end gap-8 item-center">
-                <x-layout.saved-marker :id="$challenge->katas->first()->id" />
-                    @if (auth()->user()->profile->passedKatas()->get()->contains($challenge->katas()->first()->id))
-                        <x-layout.favorite-button size="md" />
+                @php
+                    $id = $challenge->katas()->first()->id;
+                @endphp
+                <x-layout.saved-marker :id="$id" />
+                    @if (auth()->user()->profile->passedKatas()->get()->contains($id))
+                        <x-layout.favorite-button :id="$id" size="md" />
                     @endif
             </div>
         </div>

--- a/resources/views/includes/favorites.blade.php
+++ b/resources/views/includes/favorites.blade.php
@@ -1,5 +1,12 @@
-@foreach ($favoritesKatas as $favoriteKata)
-    <div class="card-challenge  grid grid-cols-12" id="{{ $favoriteKata->id }}">
+<x-layout.order-button route="{{ route('katas.favorites') }}" />
+
+@foreach ($favorites as $favorite)
+
+    @php
+        $challenge = $favorite->solution->kata->challenge;
+    @endphp
+
+    <div class="card-challenge  grid grid-cols-12" id="{{ $challenge->id }}">
 
         <aside class="handle cursor-grab flex justify-start items-center cols-span-1 transition-all duration-500 overflow-hidden">
             <div class="hubgrab"></div>
@@ -8,7 +15,7 @@
         <div class="col-span-11 relative">
             <div class="w-full flex flex-row justify-between">
                 <div class="w-full flex flex-row justify-start items-center">
-                    @foreach ($favoriteKata->challenge->categories as $category )
+                    @foreach ($challenge->categories as $category )
                         <a href="{{ route('challenges.training') }}?category={{$category->name}}">
                             <div class="bg-slate-50 dark:bg-slate-900 border border-slate-400 dark:border-slate-800 shadow-md hover:bg-violet-600 dark:hover:bg-violet-600 hover:text-slate-100 cursor-pointer px-2 rounded-lg mr-2">
                                 <span class="category">{{ $category->name }}</span>
@@ -16,23 +23,23 @@
                         </a>
 
                     @endforeach
-                    <x-utilities.rank size="4" :rank="$favoriteKata->challenge->rank->name" />
+                    <x-utilities.rank size="4" :rank="$challenge->rank->name" />
                 </div>
             </div>
 
             <div class="py-2">
-                <a href="{{ $favoriteKata->challenge->url }}" class="">
+                <a href="{{ $challenge->url }}" class="">
                     <div class="text-center text-ellipsis-1 text-xl text-violet-600 dark:text-tomato">
-                        {{ $favoriteKata->challenge->title }}
+                        {{ $challenge->title }}
                     </div>
                     <div class="text-ellipsis-3">
                         <span>
-                            {!! $favoriteKata->challenge->description !!}
+                            {!! $challenge->description !!}
                         </span>
                     </div>
                 </a>
             </div>
-            <div id="{{ $favoriteKata->id }}" class="cross-savedkata">
+            <div id="{{ $favorite->id }}" class="cross-savedkata">
                 <div class="cross">
                     &times;
                 </div>

--- a/resources/views/includes/favorites.blade.php
+++ b/resources/views/includes/favorites.blade.php
@@ -6,7 +6,7 @@
         $challenge = $favorite->solution->kata->challenge;
     @endphp
 
-    <div class="card-challenge  grid grid-cols-12" id="{{ $challenge->id }}">
+    <div class="card-challenge  grid grid-cols-12" id="{{ $favorite->id }}">
 
         <aside class="handle cursor-grab flex justify-start items-center cols-span-1 transition-all duration-500 overflow-hidden">
             <div class="hubgrab"></div>

--- a/resources/views/includes/favorites.blade.php
+++ b/resources/views/includes/favorites.blade.php
@@ -1,0 +1,45 @@
+@foreach ($favoritesKatas as $favoriteKata)
+    <div class="card-challenge  grid grid-cols-12" id="{{ $favoriteKata->id }}">
+
+        <aside class="handle cursor-grab flex justify-start items-center cols-span-1 transition-all duration-500 overflow-hidden">
+            <div class="hubgrab">
+                <div class="bar bg-slate-500/70 dark:bg-slate-500/70 transition-all duration-300"></div>
+                <div class="bar bg-slate-500/70 dark:bg-slate-500/70 transition-all duration-300"></div>
+            </div>
+        </aside>
+
+        <div class="col-span-11 relative">
+            <div class="w-full flex flex-row justify-between">
+                <div class="w-full flex flex-row justify-start items-center">
+                    @foreach ($favoriteKata->challenge->categories as $category )
+                        <a href="{{ route('challenges.training') }}?category={{$category->name}}">
+                            <div class="bg-slate-50 dark:bg-slate-900 border border-slate-400 dark:border-slate-800 shadow-md hover:bg-violet-600 dark:hover:bg-violet-600 hover:text-slate-100 cursor-pointer px-2 rounded-lg mr-2">
+                                <span class="category">{{ $category->name }}</span>
+                            </div>
+                        </a>
+
+                    @endforeach
+                    <x-utilities.rank size="4" :rank="$favoriteKata->challenge->rank->name" />
+                </div>
+            </div>
+
+            <div class="py-2">
+                <a href="{{ $favoriteKata->challenge->url }}" class="">
+                    <div class="text-center text-ellipsis-1 text-xl text-violet-600 dark:text-tomato">
+                        {{ $favoriteKata->challenge->title }}
+                    </div>
+                    <div class="text-ellipsis-3">
+                        <span>
+                            {!! $favoriteKata->challenge->description !!}
+                        </span>
+                    </div>
+                </a>
+            </div>
+            <div id="{{ $favoriteKata->id }}" class="cross-savedkata">
+                <div class="cross">
+                    &times;
+                </div>
+            </div>
+        </div>
+    </div>
+@endforeach

--- a/resources/views/includes/favorites.blade.php
+++ b/resources/views/includes/favorites.blade.php
@@ -2,10 +2,7 @@
     <div class="card-challenge  grid grid-cols-12" id="{{ $favoriteKata->id }}">
 
         <aside class="handle cursor-grab flex justify-start items-center cols-span-1 transition-all duration-500 overflow-hidden">
-            <div class="hubgrab">
-                <div class="bar bg-slate-500/70 dark:bg-slate-500/70 transition-all duration-300"></div>
-                <div class="bar bg-slate-500/70 dark:bg-slate-500/70 transition-all duration-300"></div>
-            </div>
+            <div class="hubgrab"></div>
         </aside>
 
         <div class="col-span-11 relative">

--- a/resources/views/includes/saved.blade.php
+++ b/resources/views/includes/saved.blade.php
@@ -35,9 +35,16 @@
                     </div>
                 </a>
             </div>
-            <div id="{{ $savedKata->id }}" class="cross-savedkata">
-                <div class="cross">
-                    &times;
+            <div class="absolute right-0 top-0">
+                <div class="w-56 flex flex-row justify-center items-center">
+                    @if (auth()->user()->profile->passedKatas()->get()->contains($savedKata->id))
+                        <x-layout.favorite-button size="md" />
+                    @endif
+                    <div id="{{ $savedKata->id }}" class="cross-savedkata">
+                        <div class="cross">
+                            &times;
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/resources/views/includes/saved.blade.php
+++ b/resources/views/includes/saved.blade.php
@@ -38,7 +38,7 @@
             <div class="absolute right-0 top-0">
                 <div class="w-56 flex flex-row justify-center items-center">
                     @if (auth()->user()->profile->passedKatas()->get()->contains($savedKata->id))
-                        <x-layout.favorite-button size="md" />
+                        <x-layout.favorite-button :id="$savedKata->id" size="md" />
                     @endif
                     <div id="{{ $savedKata->id }}" class="cross-savedkata">
                         <div class="cross">

--- a/resources/views/katas/favorites.blade.php
+++ b/resources/views/katas/favorites.blade.php
@@ -41,7 +41,7 @@
             <div class="col-span-12 lg:col-span-8 py-2" x-ref="challenges">
                 @if ($favorites->count())
                 <div id="list" class="lista" x-ref="list">
-                    <x-layout.order-button routeAsc="{{ route('katas.favorites') }}" routeDesc="{{ route('katas.favorites') }}" />
+                    <x-layout.order-button route="{{ route('katas.favorites') }}" />
                         @foreach ($favorites as $favorite)
 
                             @php

--- a/resources/views/katas/favorites.blade.php
+++ b/resources/views/katas/favorites.blade.php
@@ -1,0 +1,97 @@
+<x-app-layout>
+    <x-layout.wrapped-main-section>
+        @vite(['resources/js/savedkatas.js'])
+
+        <main class="grid grid-cols-12 mt-8 gap-8">
+            <div class="max-h-screen col-span-12 lg:col-span-4 sm:rounded-xl relative">
+
+                <div class="h-full w-full border overflow-hidden border-blue-600 -z-10 absolute sm:rounded-xl">
+                    <img class="w-full h-full saturate-150" src="{{ auth()->user()->profile_photo_url }}" alt="">
+                </div>
+
+                <div class="p-10 sm:border border-slate-400 sm:dark:border-cyan-600 shadow-xl sm:dark:shadow-outter-sm sm:dark:shadow-cyan-600 sm:rounded-xl bg-slate-200/70 dark:bg-slate-800/30 backdrop-blur-xl lg:min-h-screen">
+
+                    <div class="text-slate-700 dark:text-slate-100">
+                        <div class="text-4xl font-bold tracking-wider">
+                            {{ __('Favorites') }}
+                        </div>
+                        <div class="pt-5 text-lg">
+                            <a href="{{ route('dashboard') }}" class="inline-flex items-center">
+                                <div class="overflow-hidden rounded-full pr-3">
+                                    <img class="h-12 w-12 rounded-full" src="{{ auth()->user()->profile_photo_url }}" alt="">
+                                </div>
+                                <div>
+                                    {{ auth()->user()->name }}
+                                </div>
+                            </a>
+                        </div>
+                        <div class="w-full pt text-sm pt-10 inline-flex justify-evenly items-center">
+                            <span>
+                                <span
+                                    @updatefavorite.window="
+                                        $el.textContent = $event.detail;
+                                    "
+                                >{{ $totalFavorites }}</span> Favorites</span>
+                            <span>Updated {{ $lastUpdated ?? 'never' }}</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-span-12 lg:col-span-8 py-2" x-ref="challenges">
+                @if ($favoritesKatas->count())
+                    <x-layout.order-button routeAsc="{{ route('katas.favorites') }}" routeDesc="{{ route('katas.favorites') }}" />
+                    <div id="list" class="lista" x-ref="list">
+                        @foreach ($favoriteKatas as $favoriteKata)
+                            <div class="card-challenge grid grid-cols-12" id="{{ $favoriteKata->id }}">
+
+                                <aside class="handle cursor-grab flex justify-start items-center cols-span-1 transition-all duration-500 overflow-hidden">
+                                    <div class="hubgrab">
+                                        <div class="bar bg-slate-500/70 dark:bg-slate-500/70 transition-all duration-300"></div>
+                                        <div class="bar bg-slate-500/70 dark:bg-slate-500/70 transition-all duration-300"></div>
+                                    </div>
+                                </aside>
+
+                                <div class="col-span-11 relative">
+                                    <div class="w-full flex flex-row justify-between">
+                                        <div class="w-full flex flex-row justify-start items-center">
+                                            @foreach ($favoriteKata->challenge->categories as $category )
+                                                <a href="{{ route('challenges.training') }}?category={{$category->name}}">
+                                                    <div class="bg-slate-50 dark:bg-slate-900 border border-slate-400 dark:border-slate-800 shadow-md hover:bg-violet-600 dark:hover:bg-violet-600 hover:text-slate-100 cursor-pointer px-2 rounded-lg mr-2">
+                                                        <span class="category">{{ $category->name }}</span>
+                                                    </div>
+                                                </a>
+                                            @endforeach
+                                            <x-utilities.rank size="4" :rank="$favoriteKata->challenge->rank->name" />
+                                        </div>
+                                    </div>
+
+                                    <div class="py-2">
+                                        <a href="{{ $favoriteKata->challenge->url }}" class="">
+                                            <div class="text-center text-ellipsis-1 text-xl text-violet-600 dark:text-tomato">
+                                                {{ $favoriteKata->challenge->title }}
+                                            </div>
+                                            <div class="text-ellipsis-3">
+                                                <span>
+                                                    {!! $favoriteKata->challenge->description !!}
+                                                </span>
+                                            </div>
+                                        </a>
+                                    </div>
+                                    <div id="{{ $favoriteKata->id }}" class="cross-savedkata">
+                                        <div class="cross">
+                                            &times;
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+
+                @else
+                    <h1 class="flex items-center text-lg dark:text-slate-100 font-semibold justify-center">Your list its empty.</h1>
+                @endif
+            </div>
+        </main>
+    </x-layout.wrapped-main-section>
+</x-app-layout>

--- a/resources/views/katas/favorites.blade.php
+++ b/resources/views/katas/favorites.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
     <x-layout.wrapped-main-section>
-        @vite(['resources/js/savedkatas.js'])
+        @vite(['resources/js/favorites.js'])
 
         <main class="grid grid-cols-12 mt-8 gap-8">
             <div class="max-h-screen col-span-12 lg:col-span-4 sm:rounded-xl relative">
@@ -39,46 +39,48 @@
             </div>
 
             <div class="col-span-12 lg:col-span-8 py-2" x-ref="challenges">
-                @if ($favoritesKatas->count())
+                @if ($favorites->count())
+                <div id="list" class="lista" x-ref="list">
                     <x-layout.order-button routeAsc="{{ route('katas.favorites') }}" routeDesc="{{ route('katas.favorites') }}" />
-                    <div id="list" class="lista" x-ref="list">
-                        @foreach ($favoriteKatas as $favoriteKata)
-                            <div class="card-challenge grid grid-cols-12" id="{{ $favoriteKata->id }}">
+                        @foreach ($favorites as $favorite)
 
-                                <aside class="handle cursor-grab flex justify-start items-center cols-span-1 transition-all duration-500 overflow-hidden">
-                                    <div class="hubgrab">
-                                        <div class="bar bg-slate-500/70 dark:bg-slate-500/70 transition-all duration-300"></div>
-                                        <div class="bar bg-slate-500/70 dark:bg-slate-500/70 transition-all duration-300"></div>
-                                    </div>
+                            @php
+                                $challenge = $favorite->solution->kata->challenge;
+                            @endphp
+
+                            <div class="card-challenge grid grid-cols-12" id="{{ $challenge->id }}">
+
+                                <aside class="flex justify-start items-center cols-span-1 transition-all duration-500 overflow-hidden">
+                                    <div class="hubgrab"></div>
                                 </aside>
 
                                 <div class="col-span-11 relative">
                                     <div class="w-full flex flex-row justify-between">
                                         <div class="w-full flex flex-row justify-start items-center">
-                                            @foreach ($favoriteKata->challenge->categories as $category )
+                                            @foreach ($challenge->categories as $category )
                                                 <a href="{{ route('challenges.training') }}?category={{$category->name}}">
                                                     <div class="bg-slate-50 dark:bg-slate-900 border border-slate-400 dark:border-slate-800 shadow-md hover:bg-violet-600 dark:hover:bg-violet-600 hover:text-slate-100 cursor-pointer px-2 rounded-lg mr-2">
                                                         <span class="category">{{ $category->name }}</span>
                                                     </div>
                                                 </a>
                                             @endforeach
-                                            <x-utilities.rank size="4" :rank="$favoriteKata->challenge->rank->name" />
+                                            <x-utilities.rank size="4" :rank="$challenge->rank->name" />
                                         </div>
                                     </div>
 
                                     <div class="py-2">
-                                        <a href="{{ $favoriteKata->challenge->url }}" class="">
+                                        <a href="{{ $challenge->url }}" class="">
                                             <div class="text-center text-ellipsis-1 text-xl text-violet-600 dark:text-tomato">
-                                                {{ $favoriteKata->challenge->title }}
+                                                {{ $challenge->title }}
                                             </div>
                                             <div class="text-ellipsis-3">
                                                 <span>
-                                                    {!! $favoriteKata->challenge->description !!}
+                                                    {!! $challenge->description !!}
                                                 </span>
                                             </div>
                                         </a>
                                     </div>
-                                    <div id="{{ $favoriteKata->id }}" class="cross-savedkata">
+                                    <div id="{{ $challenge->id }}" class="cross-savedkata">
                                         <div class="cross">
                                             &times;
                                         </div>

--- a/resources/views/katas/favorites.blade.php
+++ b/resources/views/katas/favorites.blade.php
@@ -28,7 +28,7 @@
                         <div class="w-full pt text-sm pt-10 inline-flex justify-evenly items-center">
                             <span>
                                 <span
-                                    @updatefavorite.window="
+                                    @updatefavorites.window="
                                         $el.textContent = $event.detail;
                                     "
                                 >{{ $totalFavorites }}</span> Favorites</span>
@@ -40,15 +40,15 @@
 
             <div class="col-span-12 lg:col-span-8 py-2" x-ref="challenges">
                 @if ($favorites->count())
-                <div id="list" class="lista" x-ref="list">
-                    <x-layout.order-button route="{{ route('katas.favorites') }}" />
+                    <div id="list" class="lista" x-ref="list">
+                        <x-layout.order-button route="{{ route('katas.favorites') }}" />
                         @foreach ($favorites as $favorite)
 
                             @php
                                 $challenge = $favorite->solution->kata->challenge;
                             @endphp
 
-                            <div class="card-challenge grid grid-cols-12" id="{{ $challenge->id }}">
+                            <div class="card-challenge grid grid-cols-12" id="{{ $favorite->id }}">
 
                                 <aside class="flex justify-start items-center cols-span-1 transition-all duration-500 overflow-hidden">
                                     <div class="hubgrab"></div>
@@ -80,7 +80,7 @@
                                             </div>
                                         </a>
                                     </div>
-                                    <div id="{{ $challenge->id }}" class="cross-savedkata">
+                                    <div id="{{ $favorite->id }}" class="cross-savedkata">
                                         <div class="cross">
                                             &times;
                                         </div>
@@ -89,7 +89,6 @@
                             </div>
                         @endforeach
                     </div>
-
                 @else
                     <h1 class="flex items-center text-lg dark:text-slate-100 font-semibold justify-center">Your list its empty.</h1>
                 @endif

--- a/resources/views/katas/main-page.blade.php
+++ b/resources/views/katas/main-page.blade.php
@@ -174,6 +174,7 @@
 
                 <x-slot name="footer">
                     <x-layout.favorite-button :id="$challenge->katas->first()->id" size="xl"/>
+                        <div class="px-5"></div>
                     <form action="{{ route('katas.next') }}" method="get">
                         <x-jet-button>
                             Next Challenge

--- a/resources/views/katas/main-page.blade.php
+++ b/resources/views/katas/main-page.blade.php
@@ -1,6 +1,14 @@
 <x-app-layout>
     <x-layout.wrapped-main-section>
+        <div id="cont_btn" class="w-full flex flex-row justify-between items-center p-2">
+            <form action="{{ route('katas.change', ['id' => $previous]) }}" method="get">
+                <x-jet-button class="w-32 flex justify-center">Previous</x-jet-button>
+            </form>
 
+            <form action="{{ route('katas.change', ['id' => $next]) }}" method="get">
+                <x-jet-button id="next_btn" class="w-32 flex justify-center">Next</x-jet-button>
+            </form>
+        </div>
         <main
             x-data="{instructions: true, code: false, resources: false, solutions: false}"
             class="sm:mt-8 grid grid-flow-row sm:card-panel"
@@ -175,7 +183,7 @@
                 <x-slot name="footer">
                     <x-layout.favorite-button :id="$challenge->katas->first()->id" size="xl"/>
                         <div class="px-5"></div>
-                    <form action="{{ route('katas.next') }}" method="get">
+                    <form action="{{ route('katas.next-available') }}" method="get">
                         <x-jet-button>
                             Next Challenge
                         </x-jet-button>

--- a/resources/views/katas/saved.blade.php
+++ b/resources/views/katas/saved.blade.php
@@ -77,9 +77,16 @@
                                             </div>
                                         </a>
                                     </div>
-                                    <div id="{{ $savedKata->id }}" class="cross-savedkata">
-                                        <div class="cross">
-                                            &times;
+                                    <div class="absolute right-0 top-0">
+                                        <div class="w-56 flex flex-row justify-center items-center">
+                                            @if (auth()->user()->profile->passedKatas()->get()->contains($savedKata->id))
+                                                <x-layout.favorite-button size="md" />
+                                            @endif
+                                            <div id="{{ $savedKata->id }}" class="cross-savedkata">
+                                                <div class="cross">
+                                                    &times;
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>

--- a/resources/views/katas/saved.blade.php
+++ b/resources/views/katas/saved.blade.php
@@ -80,7 +80,7 @@
                                     <div class="absolute right-0 top-0">
                                         <div class="w-56 flex flex-row justify-center items-center">
                                             @if (auth()->user()->profile->passedKatas()->get()->contains($savedKata->id))
-                                                <x-layout.favorite-button size="md" />
+                                                <x-layout.favorite-button :id="$savedKata->id" size="md" />
                                             @endif
                                             <div id="{{ $savedKata->id }}" class="cross-savedkata">
                                                 <div class="cross">

--- a/resources/views/mail/favorite.blade.php
+++ b/resources/views/mail/favorite.blade.php
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+    @vite(['resources/css/mail.css'])
+</head>
+
+<body>
+    <div class="">
+        <div class="aHl"></div>
+        <div id=":u5" tabindex="-1"></div>
+        <div id=":4wh" class="ii gt"
+            jslog="20277; u014N:xr6bB; 1:WyIjdGhyZWFkLWY6MTc2MzI4NDAzMjc3NjI4Nzk0OCIsbnVsbCxudWxsLG51bGwsbnVsbCxudWxsLG51bGwsbnVsbCxudWxsLG51bGwsbnVsbCxudWxsLG51bGwsW11d; 4:WyIjbXNnLWY6MTc2MzI4NTE5ODc0NzU2MjAzNyIsbnVsbCxbXV0.">
+            <div id=":6nc" class="a3s aiL msg7500748536469150927"><u></u>
+
+                <div
+                    style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';background-color:#ffffff;color:#718096;height:100%;line-height:1.4;margin:0;padding:0;width:100%!important">
+
+                    <table width="100%" cellpadding="0" cellspacing="0" role="presentation"
+                        style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';background-color:#edf2f7;margin:0;padding:0;width:100%">
+                        <tbody>
+                            <tr>
+                                <td align="center"
+                                    style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol'">
+                                    <table width="100%" cellpadding="0" cellspacing="0" role="presentation"
+                                        style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';margin:0;padding:0;width:100%">
+                                        <tbody>
+                                            <tr>
+                                                <td
+                                                    style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';padding:25px 0;text-align:center">
+                                                    <a href="http://127.0.0.1:8000"
+                                                        style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';color:#3d4852;font-size:19px;font-weight:bold;text-decoration:none;display:inline-block"
+                                                        target="_blank"
+                                                        data-saferedirecturl="https://www.google.com/url?q=http://127.0.0.1:8000&amp;source=gmail&amp;ust=1681686208826000&amp;usg=AOvVaw0tCwUSZ8nxTvr3jnw10itG">
+                                                        <img src="https://ci6.googleusercontent.com/proxy/Sjg_LenFVhxOJkpABHu4vqo2QJOrQVHTKgWEfY6WkUurgGkXUCg00_AJWzLKF8__hRY=s0-d-e1-ft#https://i.imgur.com/ZHBj8Iq.png"
+                                                            alt="Katawars Logo"
+                                                            style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';max-width:100%;border:none;height:110px;max-height:110px;width:300px"
+                                                            class="CToWUd" data-bit="iit">
+                                                    </a>
+                                                </td>
+                                            </tr>
+
+                                            <tr>
+                                                <td width="100%" cellpadding="0" cellspacing="0"
+                                                    style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';background-color:#edf2f7;border-bottom:1px solid #edf2f7;border-top:1px solid #edf2f7;margin:0;padding:0;width:100%">
+                                                    <table class="m_7500748536469150927inner-body" align="center"
+                                                        width="570" cellpadding="0" cellspacing="0"
+                                                        role="presentation"
+                                                        style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';background-color:#ffffff;border-color:#e8e5ef;border-radius:2px;border-width:1px;margin:0 auto;padding:0;width:570px">
+
+                                                        <tbody>
+                                                            <tr>
+                                                                <td
+                                                                    style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';max-width:100vw;padding:32px">
+                                                                    <h1 style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';color:#3d4852;font-size:18px;font-weight:bold;margin-top:0;text-align:left">
+                                                                        {{ $greeting }}
+                                                                    </h1>
+
+                                                                    <h1 style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';color:#3d4852;font-size:18px;font-weight:bold;margin-top:0;text-align:left">
+                                                                        The user {{ $voterUsername }} add to favorite your Kata created!
+                                                                    </h1>
+
+                                                                    <a href="{{ $url }}" style="width:100%;box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';color:#3d4852;font-size:18px;font-weight:bold;margin-top:0;text-align:center">
+                                                                        {{ $challenge }}
+                                                                    </a>
+
+                                                                    @foreach ($introLines as $introLine )
+                                                                        <p style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';font-size:16px;line-height:1.5em;margin-top:0;text-align:left">
+                                                                            {{ $introLine }}
+                                                                        </p>
+                                                                    @endforeach
+
+                                                                    <table align="center" width="100%" cellpadding="0"
+                                                                        cellspacing="0" role="presentation"
+                                                                        style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';margin:30px auto;padding:0;text-align:center;width:100%">
+                                                                        <tbody>
+                                                                            <tr>
+                                                                                <td align="center"
+                                                                                    style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol'">
+                                                                                    <table width="100%" border="0"
+                                                                                        cellpadding="0" cellspacing="0"
+                                                                                        role="presentation"
+                                                                                        style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol'">
+                                                                                        <tbody>
+                                                                                            <tr>
+                                                                                                <td align="center"
+                                                                                                    style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol'">
+                                                                                                    <table
+                                                                                                        border="0"
+                                                                                                        cellpadding="0"
+                                                                                                        cellspacing="0"
+                                                                                                        role="presentation"
+                                                                                                        style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol'">
+                                                                                                        <tbody>
+                                                                                                            <tr>
+                                                                                                                <td
+                                                                                                                    style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol'">
+                                                                                                                    <h2
+                                                                                                                        class="m_7500748536469150927button"
+                                                                                                                        rel="noopener"
+                                                                                                                        style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';border-radius:4px;color:#fff;display:inline-block;overflow:hidden;text-decoration:none;background-color:#2d3748;border-bottom:8px solid #2d3748;border-left:18px solid #2d3748;border-right:18px solid #2d3748;border-top:8px solid #2d3748"
+                                                                                                                        target="_blank"
+                                                                                                                    >
+                                                                                                                        {{ $score }} {{ strtoUpper($typeScore) }}
+                                                                                                                    </h2>
+                                                                                                                </td>
+                                                                                                            </tr>
+                                                                                                        </tbody>
+                                                                                                    </table>
+                                                                                                </td>
+                                                                                            </tr>
+                                                                                        </tbody>
+                                                                                    </table>
+                                                                                </td>
+                                                                            </tr>
+                                                                        </tbody>
+                                                                    </table>
+                                                                    @foreach ($outroLines as $outroLine)
+                                                                        <p style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';font-size:16px;line-height:1.5em;margin-top:0;text-align:left">
+                                                                            {{ $outroLine }}
+                                                                        </p>
+                                                                    @endforeach
+
+                                                                    <table width="100%" cellpadding="0"
+                                                                        cellspacing="0" role="presentation"
+                                                                        style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';border-top:1px solid #e8e5ef;margin-top:25px;padding-top:25px">
+                                                                        <tbody>
+                                                                            <tr>
+                                                                                <td
+                                                                                    style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol'">
+                                                                                    <p
+                                                                                        style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';line-height:1.5em;margin-top:0;text-align:left;font-size:14px"
+                                                                                    >
+                                                                                        {{ $slogan }}
+                                                                                    </p>
+
+                                                                                </td>
+                                                                            </tr>
+                                                                        </tbody>
+                                                                    </table>
+                                                                </td>
+                                                            </tr>
+                                                        </tbody>
+                                                    </table>
+                                                </td>
+                                            </tr>
+
+                                            <tr>
+                                                <td
+                                                    style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol'">
+                                                    <table class="m_7500748536469150927footer" align="center"
+                                                        width="570" cellpadding="0" cellspacing="0"
+                                                        role="presentation"
+                                                        style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';margin:0 auto;padding:0;text-align:center;width:570px">
+                                                        <tbody>
+                                                            <tr>
+                                                                <td align="center"
+                                                                    style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';max-width:100vw;padding:32px">
+                                                                    <p
+                                                                        style="box-sizing:border-box;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif,'Apple Color Emoji','Segoe UI Emoji','Segoe UI Symbol';line-height:1.5em;margin-top:0;color:#b0adc5;font-size:12px;text-align:center">
+                                                                        © 2023 Katawars. All rights reserved.</p>
+
+                                                                </td>
+                                                            </tr>
+                                                        </tbody>
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <div class="yj6qo"></div>
+                    <div class="adL">
+                    </div>
+                </div>
+                <div class="adL">
+                </div>
+            </div>
+        </div>
+        <div id=":mc" class="ii gt" style="display:none">
+            <div id=":mb" class="a3s aiL "></div>
+        </div>
+        <div class="hi"></div>
+    </div>
+</body>
+
+</html>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -248,7 +248,7 @@
                         {{ __('Saved Katas') }}
                     </x-jet-responsive-nav-link>
 
-                    <x-jet-responsive-nav-link href="{{ route('dashboard') }}">
+                    <x-jet-responsive-nav-link href="{{ route('katas.favorites') }}">
                         {{ __('Favorites') }}
                     </x-jet-responsive-nav-link>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\Auth\GitHubLoginController;
 use App\Http\Controllers\ChallengeController;
+use App\Http\Controllers\FavoritesController;
 use App\Http\Controllers\HelpController;
 use App\Http\Controllers\SavedKatasController;
 use Illuminate\Support\Facades\Route;
@@ -114,4 +115,7 @@ Route::middleware([
 
     Route::post('/katas/{slug}/verify-kata', [ChallengeController::class, 'verifyKata'])
         ->name('katas.verify');
+
+    Route::get('/favorites', [FavoritesController::class, 'index'])
+        ->name('katas.favorites');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -98,9 +98,11 @@ Route::middleware([
     Route::get('/saved-katas', [SavedKatasController::class, 'index'])
         ->name('katas.saved');
 
+    // Add Saved Kata to the list
     Route::post('/saved-katas/{id}', [SavedKatasController::class, 'store'])
         ->name('katas.store');
 
+    // Manually Sort
     Route::patch('/saved-katas/update', [SavedKatasController::class, 'update'])
         ->name('katas.update');
 
@@ -118,4 +120,7 @@ Route::middleware([
 
     Route::get('/favorites', [FavoritesController::class, 'index'])
         ->name('katas.favorites');
+
+    Route::put('favorites/{id}', [FavoritesController::class, 'store'])
+        ->name('favorites.store');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -109,8 +109,11 @@ Route::middleware([
     Route::delete('/saved-katas/{id}', [SavedKatasController::class, 'destroy'])
         ->name('katas.destroy');
 
-    Route::get('/katas/next', [ChallengeController::class, 'showNextChallenge'])
-        ->name('katas.next');
+    Route::get('/katas/next-available', [ChallengeController::class, 'showNextChallengeAvailable'])
+        ->name('katas.next-available');
+
+    Route::get('/katas/change/{id}', [ChallengeController::class, 'changeChallenge'])
+        ->name('katas.change');
 
     Route::get('/katas/{slug}', [ChallengeController::class, 'showKataMainPage'])
         ->name('katas.main-page');

--- a/routes/web.php
+++ b/routes/web.php
@@ -123,4 +123,7 @@ Route::middleware([
 
     Route::put('favorites/{id}', [FavoritesController::class, 'store'])
         ->name('favorites.store');
+
+    Route::delete('favorites/{id}', [FavoritesController::class, 'destroy'])
+        ->name('favorites.destroy');
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,7 @@ export default defineConfig({
                 'resources/js/thememode.js',
                 'resources/js/codekata.js',
                 'resources/js/savedkatas.js',
+                'resources/js/favorites.js',
             ],
             refresh: [
                 ...refreshPaths,


### PR DESCRIPTION
Closes #58 Closes #62 Closes 48 - Se implementa funcionalidad y vista para mostrar favoritos y añadir así cómo eliminarlos. Se implementa desde la vista principal, desde el modal de reto superado, desde la vista general de retos de entrenamiento. Se establece la restricción de que el usuario no pueda añadir a favoritos si no ha superado previamente el reto. Se añaden puntos de Honor al usuario que creó el reto y se le envía un email indicando qué reto fue y que usuario así como la puntuación obtenida. Se implementa funcionalidad para poder navegar de manera circular por los retos de entrenamiento desde la página principal de los retos. Se añaden botones para redirigir a un reto anterior o posterior. Se implementa crea fachada de clase personaliza CircularCollection que permite realizar operaciones con una colección cualquiera y establece el comportamiento de lista enlazada circular a partir de un elemento pasado cualesquiera que exista en la colección.